### PR TITLE
readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Start `bitcoind`:
 $ bitcoind 
 ```
 
-`bitcoind` will now sync the blockhain. This will take a while, typically several hours. You can inspect the log to ensure that progress is made:
+`bitcoind` will now sync the blockhain. This will take a while, typically several hours. You can inspect the log to ensure that progress is made. Depending on where your `bitcoin.conf` file is, you can watch your node sync by using `tail`. For example, on macOS you can do:
 
 ```bash
 $ tail -f $HOME/Library/Application Support/Bitcoin/testnet3/debug.log

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ $ bitcoind
 `bitcoind` will now sync the blockhain. This will take a while, typically several hours. You can inspect the log to ensure that progress is made:
 
 ```bash
-$ tail -f $HOME/.bitcoin/testnet3/debug.log
+$ tail -f $HOME/Library/Application Support/Bitcoin/testnet3/debug.log
 ```
 
 ---


### PR DESCRIPTION
Definitely let me know if this doesn't make sense, but the directory change here is to match the updated "Default bitcoin datadir" on macOS, updated for this `$ tail -f` command.

Thanks!